### PR TITLE
Adds support for test mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,37 @@ class SingletonDependency {
 If a class is declared to be a `@singleton`, then one instance will be created
 the first time the class is listed as a dependency or resolved, and this
 instance will be cached and used when other classes need an instance of it.
+
+
+### Test Mocks
+
+Needlepoint includes a simple test mocking facility for replacing dependencies in a test environment.  To use it, import your container from `mockableContainer` instead of from the main project.  `mockableContainer` is a subclass of `container` that adds the ability to substitute dependencies:
+
+
+```
+import {dependencies} from 'needlepoint';
+import container from 'needlepoint/mockableContainer';
+
+class MyDependency {
+    constructor()
+}
+class MockDependency {
+    constructor()
+}
+
+@dependencies(MyDependency)
+class HasDependencies{
+    constructor(myDependency) {
+        this.dependency = myDependency;
+    }
+}
+
+describe("Mocked dependency", function(){
+    it("should substitute the real dependency for a fake", function(){
+        container.substitute(MyDependency, MockDependency);
+        var obj = container.resolve(HasDependencies);
+        expect(obj.dependency).to.be.instanceOf(MockDependency);
+    });
+});
+
+```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Needlepoint includes a simple test mocking facility for replacing dependencies i
 
 ```
 import {dependencies} from 'needlepoint';
-import container from 'needlepoint/mockableContainer';
+import container from 'needlepoint/dist/mockableContainer';
 
 class MyDependency {
     constructor()

--- a/dist/container.js
+++ b/dist/container.js
@@ -1,12 +1,12 @@
-'use strict';
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
-function _typeof(obj) { return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj; }
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
@@ -21,13 +21,13 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 var dependencies = new Map();
 var singletons = new Map();
 
-var Container = (function () {
+var Container = function () {
     function Container() {
         _classCallCheck(this, Container);
     }
 
     _createClass(Container, null, [{
-        key: 'resolve',
+        key: "resolve",
 
         /**
          * Resolve a single class to an instance, injecting dependencies as needed
@@ -53,7 +53,7 @@ var Container = (function () {
          */
 
     }, {
-        key: 'resolveAll',
+        key: "resolveAll",
         value: function resolveAll() {
             for (var _len = arguments.length, classes = Array(_len), _key = 0; _key < _len; _key++) {
                 classes[_key] = arguments[_key];
@@ -70,7 +70,7 @@ var Container = (function () {
          */
 
     }, {
-        key: 'resolveSingleton',
+        key: "resolveSingleton",
         value: function resolveSingleton(clazz) {
             if (singletons.get(clazz) === null) {
                 singletons.set(clazz, Container.resolveSingleInstance(clazz));
@@ -86,8 +86,9 @@ var Container = (function () {
          */
 
     }, {
-        key: 'resolveSingleInstance',
+        key: "resolveSingleInstance",
         value: function resolveSingleInstance(clazz) {
+            console.log("Resolving: " + clazz + " type " + (typeof clazz === "undefined" ? "undefined" : _typeof(clazz)));
             // Check and see if there are any dependencies that need to be injected
             var deps = Container.resolveAll.apply(Container, _toConsumableArray(dependencies.get(clazz) || []));
 
@@ -102,16 +103,16 @@ var Container = (function () {
          */
 
     }, {
-        key: 'normalizeClass',
+        key: "normalizeClass",
         value: function normalizeClass(clazz) {
             if (typeof clazz == 'string') {
                 // TODO: Actually resolve the class from the string name that
                 // was provided to us.
             } else if (typeof clazz == 'function') {
-                    return clazz;
-                } else {
-                    throw new Error('Unable to resolve the dependency name to the class.');
-                }
+                return clazz;
+            } else {
+                throw new Error('Unable to resolve the dependency name to the class.');
+            }
         }
 
         /**
@@ -121,9 +122,9 @@ var Container = (function () {
          */
 
     }, {
-        key: 'registerInstance',
+        key: "registerInstance",
         value: function registerInstance(clazz, instance) {
-            if ((typeof instance === 'undefined' ? 'undefined' : _typeof(instance)) != 'object' && typeof instance != 'function') {
+            if ((typeof instance === "undefined" ? "undefined" : _typeof(instance)) != 'object' && typeof instance != 'function') {
                 throw new Error('The argument passed was an invalid type.');
             }
 
@@ -139,7 +140,7 @@ var Container = (function () {
          */
 
     }, {
-        key: 'registerDependencies',
+        key: "registerDependencies",
         value: function registerDependencies(clazz, deps) {
             dependencies.set(clazz, deps);
         }
@@ -151,7 +152,7 @@ var Container = (function () {
          */
 
     }, {
-        key: 'registerAsSingleton',
+        key: "registerAsSingleton",
         value: function registerAsSingleton(clazz) {
             if (!singletons.has(clazz)) {
                 singletons.set(clazz, null);
@@ -160,6 +161,6 @@ var Container = (function () {
     }]);
 
     return Container;
-})();
+}();
 
 exports.default = Container;

--- a/dist/container.js
+++ b/dist/container.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, "__esModule", {
     value: true
@@ -27,17 +27,17 @@ var Container = function () {
     }
 
     _createClass(Container, null, [{
-        key: "getSingletons",
+        key: 'getSingletons',
         value: function getSingletons() {
             return singletons;
         }
     }, {
-        key: "getDependencies",
+        key: 'getDependencies',
         value: function getDependencies() {
             return dependencies;
         }
     }, {
-        key: "resolve",
+        key: 'resolve',
 
         /**
          * Resolve a single class to an instance, injecting dependencies as needed
@@ -63,7 +63,7 @@ var Container = function () {
          */
 
     }, {
-        key: "resolveAll",
+        key: 'resolveAll',
         value: function resolveAll() {
             for (var _len = arguments.length, classes = Array(_len), _key = 0; _key < _len; _key++) {
                 classes[_key] = arguments[_key];
@@ -80,7 +80,7 @@ var Container = function () {
          */
 
     }, {
-        key: "resolveSingleton",
+        key: 'resolveSingleton',
         value: function resolveSingleton(clazz) {
             if (singletons.get(clazz) === null) {
                 singletons.set(clazz, Container.resolveSingleInstance(clazz));
@@ -96,9 +96,8 @@ var Container = function () {
          */
 
     }, {
-        key: "resolveSingleInstance",
+        key: 'resolveSingleInstance',
         value: function resolveSingleInstance(clazz) {
-            console.log("C Resolving: " + clazz + " type " + (typeof clazz === "undefined" ? "undefined" : _typeof(clazz)));
             // Check and see if there are any dependencies that need to be injected
             var deps = Container.resolveAll.apply(Container, _toConsumableArray(dependencies.get(clazz) || []));
 
@@ -113,7 +112,7 @@ var Container = function () {
          */
 
     }, {
-        key: "normalizeClass",
+        key: 'normalizeClass',
         value: function normalizeClass(clazz) {
             if (typeof clazz == 'string') {
                 // TODO: Actually resolve the class from the string name that
@@ -132,9 +131,9 @@ var Container = function () {
          */
 
     }, {
-        key: "registerInstance",
+        key: 'registerInstance',
         value: function registerInstance(clazz, instance) {
-            if ((typeof instance === "undefined" ? "undefined" : _typeof(instance)) != 'object' && typeof instance != 'function') {
+            if ((typeof instance === 'undefined' ? 'undefined' : _typeof(instance)) != 'object' && typeof instance != 'function') {
                 throw new Error('The argument passed was an invalid type.');
             }
 
@@ -150,7 +149,7 @@ var Container = function () {
          */
 
     }, {
-        key: "registerDependencies",
+        key: 'registerDependencies',
         value: function registerDependencies(clazz, deps) {
             dependencies.set(clazz, deps);
         }
@@ -162,7 +161,7 @@ var Container = function () {
          */
 
     }, {
-        key: "registerAsSingleton",
+        key: 'registerAsSingleton',
         value: function registerAsSingleton(clazz) {
             if (!singletons.has(clazz)) {
                 singletons.set(clazz, null);

--- a/dist/container.js
+++ b/dist/container.js
@@ -27,6 +27,16 @@ var Container = function () {
     }
 
     _createClass(Container, null, [{
+        key: "getSingletons",
+        value: function getSingletons() {
+            return singletons;
+        }
+    }, {
+        key: "getDependencies",
+        value: function getDependencies() {
+            return dependencies;
+        }
+    }, {
         key: "resolve",
 
         /**
@@ -88,7 +98,7 @@ var Container = function () {
     }, {
         key: "resolveSingleInstance",
         value: function resolveSingleInstance(clazz) {
-            console.log("Resolving: " + clazz + " type " + (typeof clazz === "undefined" ? "undefined" : _typeof(clazz)));
+            console.log("C Resolving: " + clazz + " type " + (typeof clazz === "undefined" ? "undefined" : _typeof(clazz)));
             // Check and see if there are any dependencies that need to be injected
             var deps = Container.resolveAll.apply(Container, _toConsumableArray(dependencies.get(clazz) || []));
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -31,4 +31,13 @@ Object.defineProperty(exports, 'dependencies', {
   }
 });
 
+var _mockableContainer = require('./mockableContainer');
+
+Object.defineProperty(exports, 'mockableContainer', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_mockableContainer).default;
+  }
+});
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/dist/index.js
+++ b/dist/index.js
@@ -31,13 +31,4 @@ Object.defineProperty(exports, 'dependencies', {
   }
 });
 
-var _mockableContainer = require('./mockableContainer');
-
-Object.defineProperty(exports, 'mockableContainer', {
-  enumerable: true,
-  get: function get() {
-    return _interopRequireDefault(_mockableContainer).default;
-  }
-});
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,7 +9,7 @@ var _container = require('./container');
 Object.defineProperty(exports, 'container', {
   enumerable: true,
   get: function get() {
-    return _container.default;
+    return _interopRequireDefault(_container).default;
   }
 });
 
@@ -18,7 +18,7 @@ var _singleton = require('./singleton');
 Object.defineProperty(exports, 'singleton', {
   enumerable: true,
   get: function get() {
-    return _singleton.default;
+    return _interopRequireDefault(_singleton).default;
   }
 });
 
@@ -27,6 +27,8 @@ var _dependencies = require('./dependencies');
 Object.defineProperty(exports, 'dependencies', {
   enumerable: true,
   get: function get() {
-    return _dependencies.default;
+    return _interopRequireDefault(_dependencies).default;
   }
 });
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/dist/mockableContainer.js
+++ b/dist/mockableContainer.js
@@ -42,31 +42,6 @@ var MockableContainer = function (_Container) {
             substitutions.set(original, replacement);
         }
 
-        // /**
-        //  * Resolve a single class to an instance, injecting dependencies as needed
-        //  * @param  {class|string} clazz
-        //  * @return {object}       Instance of the class
-        //  */
-        // static resolve(clazz) {
-        //     clazz = Container.normalizeClass(clazz);
-
-        //     console.log("MC Resolving:"+ clazz);
-        //     substitutions.forEach(function(value, key){
-        //       console.log(key + " -> " + value);
-        //     });
-
-        //     console.log("substitutions keys: " + substitutions.keys());
-        //     // If the class being injected is a singleton, handle it separately
-        //     // since instances of it are cached.
-        //     if(substitutions.has(clazz)) {
-        //         var substituted = substitutions.get(clazz);
-        //         console.log("instantiating: " + substituted);
-        //         return new substituted();
-        //     } else {
-        //         return Container.resolve(clazz);
-        //     }
-        // }
-
         /**
         * Resolve a single class to an instance, injecting dependencies as needed
         * @param  {class|string} clazz
@@ -141,6 +116,11 @@ var MockableContainer = function (_Container) {
                 // Apply the dependencies and create a new instance of the class
                 return new (Function.prototype.bind.apply(clazz, [null].concat(_toConsumableArray(deps))))();
             }
+        }
+    }, {
+        key: "clear",
+        value: function clear() {
+            substitutions.clear();
         }
     }]);
 

--- a/dist/mockableContainer.js
+++ b/dist/mockableContainer.js
@@ -1,17 +1,15 @@
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
 exports.default = undefined;
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
-
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
-var _container = require("./container");
+var _container = require('./container');
 
 var _container2 = _interopRequireDefault(_container);
 
@@ -37,7 +35,7 @@ var MockableContainer = function (_Container) {
     }
 
     _createClass(MockableContainer, null, [{
-        key: "substitute",
+        key: 'substitute',
         value: function substitute(original, replacement) {
             substitutions.set(original, replacement);
         }
@@ -49,14 +47,14 @@ var MockableContainer = function (_Container) {
         */
 
     }, {
-        key: "resolve",
+        key: 'resolve',
         value: function resolve(clazz) {
             clazz = _container2.default.normalizeClass(clazz);
 
             // If the class being injected is a singleton, handle it separately
             // since instances of it are cached.
-            if (_get(Object.getPrototypeOf(MockableContainer), "getSingletons", this).call(this).has(clazz)) {
-                return MockableContainer.resolveSingleton(clazz);
+            if (_get(Object.getPrototypeOf(MockableContainer), 'getSingletons', this).call(this).has(clazz)) {
+                return _get(Object.getPrototypeOf(MockableContainer), 'resolveSingleton', this).call(this, clazz);
             } else {
                 return MockableContainer.resolveSingleInstance(clazz);
             }
@@ -69,32 +67,13 @@ var MockableContainer = function (_Container) {
          */
 
     }, {
-        key: "resolveAll",
+        key: 'resolveAll',
         value: function resolveAll() {
-            console.log("MC resolveAll");
-
             for (var _len = arguments.length, classes = Array(_len), _key = 0; _key < _len; _key++) {
                 classes[_key] = arguments[_key];
             }
 
             return classes.map(MockableContainer.resolve);
-        }
-
-        /**
-         * Resolve a class into a singleton instance. This single instance will be
-         * used across the entire application.
-         * @param  {class|string} clazz
-         * @return {object}       Resolved instance of the class as a singleton
-         */
-
-    }, {
-        key: "resolveSingleton",
-        value: function resolveSingleton(clazz) {
-            if (_get(Object.getPrototypeOf(MockableContainer), "getSingletons", this).call(this).get(clazz) === null) {
-                _get(Object.getPrototypeOf(MockableContainer), "getSingletons", this).call(this).set(clazz, MockableContainer.resolveSingleInstance(clazz));
-            }
-
-            return _get(Object.getPrototypeOf(MockableContainer), "getSingletons", this).call(this).get(clazz);
         }
 
         /**
@@ -104,11 +83,10 @@ var MockableContainer = function (_Container) {
          */
 
     }, {
-        key: "resolveSingleInstance",
+        key: 'resolveSingleInstance',
         value: function resolveSingleInstance(clazz) {
-            console.log("MC Resolving: " + clazz + " type " + (typeof clazz === "undefined" ? "undefined" : _typeof(clazz)));
             // Check and see if there are any dependencies that need to be injected
-            var deps = MockableContainer.resolveAll.apply(MockableContainer, _toConsumableArray(_get(Object.getPrototypeOf(MockableContainer), "getDependencies", this).call(this).get(clazz) || []));
+            var deps = MockableContainer.resolveAll.apply(MockableContainer, _toConsumableArray(_get(Object.getPrototypeOf(MockableContainer), 'getDependencies', this).call(this).get(clazz) || []));
             if (substitutions.has(clazz)) {
                 var sub = substitutions.get(clazz);
                 return new (Function.prototype.bind.apply(sub, [null].concat(_toConsumableArray(deps))))();
@@ -118,7 +96,7 @@ var MockableContainer = function (_Container) {
             }
         }
     }, {
-        key: "clear",
+        key: 'clear',
         value: function clear() {
             substitutions.clear();
         }

--- a/dist/mockableContainer.js
+++ b/dist/mockableContainer.js
@@ -1,0 +1,32 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = undefined;
+
+var _container2 = require('./container');
+
+var _container3 = _interopRequireDefault(_container2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var mockableContainer = function (_container) {
+  _inherits(mockableContainer, _container);
+
+  function mockableContainer() {
+    _classCallCheck(this, mockableContainer);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(mockableContainer).apply(this, arguments));
+  }
+
+  return mockableContainer;
+}(_container3.default);
+
+exports.default = mockableContainer;

--- a/dist/mockableContainer.js
+++ b/dist/mockableContainer.js
@@ -9,11 +9,7 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
 
-var _container = require('./container');
-
-var _container2 = _interopRequireDefault(_container);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var _index = require('./index');
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
@@ -25,8 +21,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var substitutions = new Map();
 
-var MockableContainer = function (_Container) {
-  _inherits(MockableContainer, _Container);
+var MockableContainer = function (_container) {
+  _inherits(MockableContainer, _container);
 
   function MockableContainer() {
     _classCallCheck(this, MockableContainer);
@@ -39,7 +35,7 @@ var MockableContainer = function (_Container) {
     value: function substitute(original, replacement) {
 
       // If any substitutions are made, replace Container's resolve function
-      Object.assign(_container2.default, {
+      Object.assign(_index.container, {
         resolveSingleInstance: MockableContainer.mockableResolveSingleInstance
       });
       substitutions.set(original, replacement);
@@ -55,7 +51,7 @@ var MockableContainer = function (_Container) {
     key: 'mockableResolveSingleInstance',
     value: function mockableResolveSingleInstance(clazz) {
       // Check and see if there are any dependencies that need to be injected
-      var deps = _container2.default.resolveAll.apply(_container2.default, _toConsumableArray(_get(Object.getPrototypeOf(MockableContainer), 'getDependencies', this).call(this).get(clazz) || []));
+      var deps = _index.container.resolveAll.apply(_index.container, _toConsumableArray(_get(Object.getPrototypeOf(MockableContainer), 'getDependencies', this).call(this).get(clazz) || []));
       if (substitutions.has(clazz)) {
         var sub = substitutions.get(clazz);
         return new (Function.prototype.bind.apply(sub, [null].concat(_toConsumableArray(deps))))();
@@ -72,6 +68,6 @@ var MockableContainer = function (_Container) {
   }]);
 
   return MockableContainer;
-}(_container2.default);
+}(_index.container);
 
 exports.default = MockableContainer;

--- a/dist/mockableContainer.js
+++ b/dist/mockableContainer.js
@@ -1,7 +1,7 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 exports.default = undefined;
 
@@ -26,83 +26,52 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var substitutions = new Map();
 
 var MockableContainer = function (_Container) {
-    _inherits(MockableContainer, _Container);
+  _inherits(MockableContainer, _Container);
 
-    function MockableContainer() {
-        _classCallCheck(this, MockableContainer);
+  function MockableContainer() {
+    _classCallCheck(this, MockableContainer);
 
-        return _possibleConstructorReturn(this, Object.getPrototypeOf(MockableContainer).apply(this, arguments));
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(MockableContainer).apply(this, arguments));
+  }
+
+  _createClass(MockableContainer, null, [{
+    key: 'substitute',
+    value: function substitute(original, replacement) {
+
+      // If any substitutions are made, replace Container's resolve function
+      Object.assign(_container2.default, {
+        resolveSingleInstance: MockableContainer.mockableResolveSingleInstance
+      });
+      substitutions.set(original, replacement);
     }
 
-    _createClass(MockableContainer, null, [{
-        key: 'substitute',
-        value: function substitute(original, replacement) {
-            substitutions.set(original, replacement);
-        }
+    /**
+     * Resolve a class into an instance with all of its dependencies injected.
+     * @param  {class|string} clazz
+     * @return {object}       Resolved instance of the class
+     */
 
-        /**
-        * Resolve a single class to an instance, injecting dependencies as needed
-        * @param  {class|string} clazz
-        * @return {object}       Instance of the class
-        */
+  }, {
+    key: 'mockableResolveSingleInstance',
+    value: function mockableResolveSingleInstance(clazz) {
+      // Check and see if there are any dependencies that need to be injected
+      var deps = _container2.default.resolveAll.apply(_container2.default, _toConsumableArray(_get(Object.getPrototypeOf(MockableContainer), 'getDependencies', this).call(this).get(clazz) || []));
+      if (substitutions.has(clazz)) {
+        var sub = substitutions.get(clazz);
+        return new (Function.prototype.bind.apply(sub, [null].concat(_toConsumableArray(deps))))();
+      } else {
+        // Apply the dependencies and create a new instance of the class
+        return new (Function.prototype.bind.apply(clazz, [null].concat(_toConsumableArray(deps))))();
+      }
+    }
+  }, {
+    key: 'clear',
+    value: function clear() {
+      substitutions.clear();
+    }
+  }]);
 
-    }, {
-        key: 'resolve',
-        value: function resolve(clazz) {
-            clazz = _container2.default.normalizeClass(clazz);
-
-            // If the class being injected is a singleton, handle it separately
-            // since instances of it are cached.
-            if (_get(Object.getPrototypeOf(MockableContainer), 'getSingletons', this).call(this).has(clazz)) {
-                return _get(Object.getPrototypeOf(MockableContainer), 'resolveSingleton', this).call(this, clazz);
-            } else {
-                return MockableContainer.resolveSingleInstance(clazz);
-            }
-        }
-
-        /**
-         * Resolve the specified classes, injecting dependencies as needed
-         * @param  {class|string} ...classes
-         * @return {...object}
-         */
-
-    }, {
-        key: 'resolveAll',
-        value: function resolveAll() {
-            for (var _len = arguments.length, classes = Array(_len), _key = 0; _key < _len; _key++) {
-                classes[_key] = arguments[_key];
-            }
-
-            return classes.map(MockableContainer.resolve);
-        }
-
-        /**
-         * Resolve a class into an instance with all of its dependencies injected.
-         * @param  {class|string} clazz
-         * @return {object}       Resolved instance of the class
-         */
-
-    }, {
-        key: 'resolveSingleInstance',
-        value: function resolveSingleInstance(clazz) {
-            // Check and see if there are any dependencies that need to be injected
-            var deps = MockableContainer.resolveAll.apply(MockableContainer, _toConsumableArray(_get(Object.getPrototypeOf(MockableContainer), 'getDependencies', this).call(this).get(clazz) || []));
-            if (substitutions.has(clazz)) {
-                var sub = substitutions.get(clazz);
-                return new (Function.prototype.bind.apply(sub, [null].concat(_toConsumableArray(deps))))();
-            } else {
-                // Apply the dependencies and create a new instance of the class
-                return new (Function.prototype.bind.apply(clazz, [null].concat(_toConsumableArray(deps))))();
-            }
-        }
-    }, {
-        key: 'clear',
-        value: function clear() {
-            substitutions.clear();
-        }
-    }]);
-
-    return MockableContainer;
+  return MockableContainer;
 }(_container2.default);
 
 exports.default = MockableContainer;

--- a/dist/mockableContainer.js
+++ b/dist/mockableContainer.js
@@ -1,15 +1,23 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 exports.default = undefined;
 
-var _container2 = require('./container');
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
-var _container3 = _interopRequireDefault(_container2);
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+
+var _container = require("./container");
+
+var _container2 = _interopRequireDefault(_container);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -17,16 +25,126 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var mockableContainer = function (_container) {
-  _inherits(mockableContainer, _container);
+var substitutions = new Map();
 
-  function mockableContainer() {
-    _classCallCheck(this, mockableContainer);
+var MockableContainer = function (_Container) {
+    _inherits(MockableContainer, _Container);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(mockableContainer).apply(this, arguments));
-  }
+    function MockableContainer() {
+        _classCallCheck(this, MockableContainer);
 
-  return mockableContainer;
-}(_container3.default);
+        return _possibleConstructorReturn(this, Object.getPrototypeOf(MockableContainer).apply(this, arguments));
+    }
 
-exports.default = mockableContainer;
+    _createClass(MockableContainer, null, [{
+        key: "substitute",
+        value: function substitute(original, replacement) {
+            substitutions.set(original, replacement);
+        }
+
+        // /**
+        //  * Resolve a single class to an instance, injecting dependencies as needed
+        //  * @param  {class|string} clazz
+        //  * @return {object}       Instance of the class
+        //  */
+        // static resolve(clazz) {
+        //     clazz = Container.normalizeClass(clazz);
+
+        //     console.log("MC Resolving:"+ clazz);
+        //     substitutions.forEach(function(value, key){
+        //       console.log(key + " -> " + value);
+        //     });
+
+        //     console.log("substitutions keys: " + substitutions.keys());
+        //     // If the class being injected is a singleton, handle it separately
+        //     // since instances of it are cached.
+        //     if(substitutions.has(clazz)) {
+        //         var substituted = substitutions.get(clazz);
+        //         console.log("instantiating: " + substituted);
+        //         return new substituted();
+        //     } else {
+        //         return Container.resolve(clazz);
+        //     }
+        // }
+
+        /**
+        * Resolve a single class to an instance, injecting dependencies as needed
+        * @param  {class|string} clazz
+        * @return {object}       Instance of the class
+        */
+
+    }, {
+        key: "resolve",
+        value: function resolve(clazz) {
+            clazz = _container2.default.normalizeClass(clazz);
+
+            // If the class being injected is a singleton, handle it separately
+            // since instances of it are cached.
+            if (_get(Object.getPrototypeOf(MockableContainer), "getSingletons", this).call(this).has(clazz)) {
+                return MockableContainer.resolveSingleton(clazz);
+            } else {
+                return MockableContainer.resolveSingleInstance(clazz);
+            }
+        }
+
+        /**
+         * Resolve the specified classes, injecting dependencies as needed
+         * @param  {class|string} ...classes
+         * @return {...object}
+         */
+
+    }, {
+        key: "resolveAll",
+        value: function resolveAll() {
+            console.log("MC resolveAll");
+
+            for (var _len = arguments.length, classes = Array(_len), _key = 0; _key < _len; _key++) {
+                classes[_key] = arguments[_key];
+            }
+
+            return classes.map(MockableContainer.resolve);
+        }
+
+        /**
+         * Resolve a class into a singleton instance. This single instance will be
+         * used across the entire application.
+         * @param  {class|string} clazz
+         * @return {object}       Resolved instance of the class as a singleton
+         */
+
+    }, {
+        key: "resolveSingleton",
+        value: function resolveSingleton(clazz) {
+            if (_get(Object.getPrototypeOf(MockableContainer), "getSingletons", this).call(this).get(clazz) === null) {
+                _get(Object.getPrototypeOf(MockableContainer), "getSingletons", this).call(this).set(clazz, MockableContainer.resolveSingleInstance(clazz));
+            }
+
+            return _get(Object.getPrototypeOf(MockableContainer), "getSingletons", this).call(this).get(clazz);
+        }
+
+        /**
+         * Resolve a class into an instance with all of its dependencies injected.
+         * @param  {class|string} clazz
+         * @return {object}       Resolved instance of the class
+         */
+
+    }, {
+        key: "resolveSingleInstance",
+        value: function resolveSingleInstance(clazz) {
+            console.log("MC Resolving: " + clazz + " type " + (typeof clazz === "undefined" ? "undefined" : _typeof(clazz)));
+            // Check and see if there are any dependencies that need to be injected
+            var deps = MockableContainer.resolveAll.apply(MockableContainer, _toConsumableArray(_get(Object.getPrototypeOf(MockableContainer), "getDependencies", this).call(this).get(clazz) || []));
+            if (substitutions.has(clazz)) {
+                var sub = substitutions.get(clazz);
+                return new (Function.prototype.bind.apply(sub, [null].concat(_toConsumableArray(deps))))();
+            } else {
+                // Apply the dependencies and create a new instance of the class
+                return new (Function.prototype.bind.apply(clazz, [null].concat(_toConsumableArray(deps))))();
+            }
+        }
+    }]);
+
+    return MockableContainer;
+}(_container2.default);
+
+exports.default = MockableContainer;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.5",
   "description": "ES6 and beyond dependency injection framework. Uses new ES7 proposals such as decorators.",
   "main": "dist/index.js",
+  "files": [ "dist/" ],
   "scripts": {
     "test": "rm -rf coverage/ dist/ && ./node_modules/.bin/babel-node ./node_modules/.bin/isparta cover --report lcovonly ./node_modules/.bin/_mocha test/ && npm run-script build",
     "build": "rm -rf dist/ && ./node_modules/.bin/babel src --out-dir dist/",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.5",
   "description": "ES6 and beyond dependency injection framework. Uses new ES7 proposals such as decorators.",
   "main": "dist/index.js",
+  "files": [
+    "dist/mockableContainer.js"
+  ],
   "scripts": {
     "test": "rm -rf coverage/ dist/ && ./node_modules/.bin/babel-node ./node_modules/.bin/isparta cover --report lcovonly ./node_modules/.bin/_mocha test/ && npm run-script build",
     "build": "rm -rf dist/ && ./node_modules/.bin/babel src --out-dir dist/",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "di"
   ],
   "author": "Andrew Munsell <andrew@wizardapps.net>",
+  "contributors": [
+    "Andrew Munsell <andrew@wizardapps.net>",
+    "Evan Dorn <evan@idahoev.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/andrewmunsell/needlepoint/issues"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.5",
   "description": "ES6 and beyond dependency injection framework. Uses new ES7 proposals such as decorators.",
   "main": "dist/index.js",
-  "files": [
-    "dist/mockableContainer.js"
-  ],
   "scripts": {
     "test": "rm -rf coverage/ dist/ && ./node_modules/.bin/babel-node ./node_modules/.bin/isparta cover --report lcovonly ./node_modules/.bin/_mocha test/ && npm run-script build",
     "build": "rm -rf dist/ && ./node_modules/.bin/babel src --out-dir dist/",

--- a/src/container.js
+++ b/src/container.js
@@ -8,6 +8,8 @@ var dependencies = new Map();
 var singletons = new Map();
 
 export default class Container {
+    static getSingletons() { return singletons };
+    static getDependencies() { return dependencies };
     /**
      * Resolve a single class to an instance, injecting dependencies as needed
      * @param  {class|string} clazz
@@ -54,7 +56,7 @@ export default class Container {
      * @return {object}       Resolved instance of the class
      */
     static resolveSingleInstance(clazz) {
-        console.log("Resolving: " + clazz + " type " + typeof(clazz));
+        console.log("C Resolving: " + clazz + " type " + typeof(clazz));
         // Check and see if there are any dependencies that need to be injected
         var deps = Container.resolveAll(...(dependencies.get(clazz) || []));
 

--- a/src/container.js
+++ b/src/container.js
@@ -56,7 +56,6 @@ export default class Container {
      * @return {object}       Resolved instance of the class
      */
     static resolveSingleInstance(clazz) {
-        console.log("C Resolving: " + clazz + " type " + typeof(clazz));
         // Check and see if there are any dependencies that need to be injected
         var deps = Container.resolveAll(...(dependencies.get(clazz) || []));
 

--- a/src/container.js
+++ b/src/container.js
@@ -54,6 +54,7 @@ export default class Container {
      * @return {object}       Resolved instance of the class
      */
     static resolveSingleInstance(clazz) {
+        console.log("Resolving: " + clazz + " type " + typeof(clazz));
         // Check and see if there are any dependencies that need to be injected
         var deps = Container.resolveAll(...(dependencies.get(clazz) || []));
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,4 +9,4 @@ export {default as container} from './container';
 export {default as singleton} from './singleton';
 export {default as dependencies} from './dependencies';
 
-export {default as mockableContainer} from './mockableContainer';
+// export {default as mockableContainer} from './mockableContainer';

--- a/src/index.js
+++ b/src/index.js
@@ -8,5 +8,3 @@ export {default as container} from './container';
 // Decorators
 export {default as singleton} from './singleton';
 export {default as dependencies} from './dependencies';
-
-// export {default as mockableContainer} from './mockableContainer';

--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,5 @@ export {default as container} from './container';
 // Decorators
 export {default as singleton} from './singleton';
 export {default as dependencies} from './dependencies';
+
+export {default as mockableContainer} from './mockableContainer';

--- a/src/mockableContainer.js
+++ b/src/mockableContainer.js
@@ -1,0 +1,5 @@
+import container from './container';
+
+export default class mockableContainer extends container {
+
+}

--- a/src/mockableContainer.js
+++ b/src/mockableContainer.js
@@ -1,12 +1,12 @@
-import Container from './container';
+import { container } from './index';
 
 var substitutions = new Map();
 
-export default class MockableContainer extends Container {
+export default class MockableContainer extends container {
     static substitute(original, replacement) {
 
       // If any substitutions are made, replace Container's resolve function
-      Object.assign(Container, {
+      Object.assign(container, {
         resolveSingleInstance: MockableContainer.mockableResolveSingleInstance
       })
       substitutions.set(original, replacement);
@@ -19,7 +19,7 @@ export default class MockableContainer extends Container {
      */
     static mockableResolveSingleInstance(clazz) {
         // Check and see if there are any dependencies that need to be injected
-        var deps = Container.resolveAll(...(super.getDependencies().get(clazz) || []));
+        var deps = container.resolveAll(...(super.getDependencies().get(clazz) || []));
         if(substitutions.has(clazz)) {
           var sub = substitutions.get(clazz);
           return new sub(...deps);

--- a/src/mockableContainer.js
+++ b/src/mockableContainer.js
@@ -1,5 +1,69 @@
-import container from './container';
+import Container from './container';
 
-export default class mockableContainer extends container {
+var substitutions = new Map();
 
+export default class MockableContainer extends Container {
+    static substitute(original, replacement) {
+       substitutions.set(original, replacement);
+    }
+
+
+        /**
+     * Resolve a single class to an instance, injecting dependencies as needed
+     * @param  {class|string} clazz
+     * @return {object}       Instance of the class
+     */
+    static resolve(clazz) {
+        clazz = Container.normalizeClass(clazz);
+
+        // If the class being injected is a singleton, handle it separately
+        // since instances of it are cached.
+        if(super.getSingletons().has(clazz)) {
+            return MockableContainer.resolveSingleton(clazz);
+        } else {
+            return MockableContainer.resolveSingleInstance(clazz);
+        }
+    }
+
+    /**
+     * Resolve the specified classes, injecting dependencies as needed
+     * @param  {class|string} ...classes
+     * @return {...object}
+     */
+    static resolveAll(...classes) {
+        console.log("MC resolveAll");
+        return classes.map(MockableContainer.resolve);
+    }
+
+    /**
+     * Resolve a class into a singleton instance. This single instance will be
+     * used across the entire application.
+     * @param  {class|string} clazz
+     * @return {object}       Resolved instance of the class as a singleton
+     */
+    static resolveSingleton(clazz) {
+        if(super.getSingletons().get(clazz) === null) {
+            super.getSingletons().set(clazz, MockableContainer.resolveSingleInstance(clazz));
+        }
+
+        return super.getSingletons().get(clazz);
+    }
+
+    /**
+     * Resolve a class into an instance with all of its dependencies injected.
+     * @param  {class|string} clazz
+     * @return {object}       Resolved instance of the class
+     */
+    static resolveSingleInstance(clazz) {
+        console.log("MC Resolving: " + clazz + " type " + typeof(clazz));
+        // Check and see if there are any dependencies that need to be injected
+        var deps = MockableContainer.resolveAll(...(super.getDependencies().get(clazz) || []));
+        if(substitutions.has(clazz)) {
+          var sub = substitutions.get(clazz);
+          return new sub(...deps);
+        } else {
+          // Apply the dependencies and create a new instance of the class
+          return new clazz(...deps);
+        }
+    }
 }

--- a/src/mockableContainer.js
+++ b/src/mockableContainer.js
@@ -7,8 +7,7 @@ export default class MockableContainer extends Container {
        substitutions.set(original, replacement);
     }
 
-
-        /**
+     /**
      * Resolve a single class to an instance, injecting dependencies as needed
      * @param  {class|string} clazz
      * @return {object}       Instance of the class
@@ -19,7 +18,7 @@ export default class MockableContainer extends Container {
         // If the class being injected is a singleton, handle it separately
         // since instances of it are cached.
         if(super.getSingletons().has(clazz)) {
-            return MockableContainer.resolveSingleton(clazz);
+            return super.resolveSingleton(clazz);
         } else {
             return MockableContainer.resolveSingleInstance(clazz);
         }
@@ -31,22 +30,7 @@ export default class MockableContainer extends Container {
      * @return {...object}
      */
     static resolveAll(...classes) {
-        console.log("MC resolveAll");
         return classes.map(MockableContainer.resolve);
-    }
-
-    /**
-     * Resolve a class into a singleton instance. This single instance will be
-     * used across the entire application.
-     * @param  {class|string} clazz
-     * @return {object}       Resolved instance of the class as a singleton
-     */
-    static resolveSingleton(clazz) {
-        if(super.getSingletons().get(clazz) === null) {
-            super.getSingletons().set(clazz, MockableContainer.resolveSingleInstance(clazz));
-        }
-
-        return super.getSingletons().get(clazz);
     }
 
     /**
@@ -55,7 +39,6 @@ export default class MockableContainer extends Container {
      * @return {object}       Resolved instance of the class
      */
     static resolveSingleInstance(clazz) {
-        console.log("MC Resolving: " + clazz + " type " + typeof(clazz));
         // Check and see if there are any dependencies that need to be injected
         var deps = MockableContainer.resolveAll(...(super.getDependencies().get(clazz) || []));
         if(substitutions.has(clazz)) {

--- a/src/mockableContainer.js
+++ b/src/mockableContainer.js
@@ -66,4 +66,8 @@ export default class MockableContainer extends Container {
           return new clazz(...deps);
         }
     }
+
+    static clear() {
+      substitutions.clear();
+    }
 }

--- a/test/mockableContainer.js
+++ b/test/mockableContainer.js
@@ -49,6 +49,12 @@ class MockDummyDependency{
   constructor() {}
 }
 
+@singleton
+class MockSingleton {
+
+}
+
+
 describe('mockableContainer', function() {
     afterEach(function(){
       mockableContainer.clear();
@@ -82,6 +88,18 @@ describe('mockableContainer', function() {
             expect(dummyClass.getDependency()).to.be.an.instanceOf(MockDummyDependency);
             expect(dummyClass.getDependency().getDependency).to.be.undefined;
         });
+        it('should resolve substituted singletons', function() {
+            mockableContainer.substitute(Singleton, MockSingleton);
+
+            var singletonInstance = mockableContainer.resolve(Singleton);
+
+            singletonInstance.value = 'hello-world';
+
+            var singletonInstanceTwo = mockableContainer.resolve(Singleton);
+            expect(singletonInstance).to.be.an.instanceOf(MockSingleton);
+            expect(singletonInstance).to.equal(singletonInstanceTwo);
+            expect(singletonInstance.value).to.equal(singletonInstanceTwo.value);
+        })
     });
 
     context("without mocks specified", function() {

--- a/test/mockableContainer.js
+++ b/test/mockableContainer.js
@@ -50,15 +50,40 @@ class MockDummyDependency{
 }
 
 describe('mockableContainer', function() {
+    afterEach(function(){
+      mockableContainer.clear();
+    });
 
     context("with mocks specified", function(){
-        it.only('should resolve a class with a single mocked dependency', function() {
+        it('should resolve a class with a single mocked dependency', function() {
             mockableContainer.substitute(DummyDependency, MockDummyDependency);
             var dummyClass = mockableContainer.resolve(DummyWithDependency);
 
             expect(dummyClass).to.be.an.instanceOf(DummyWithDependency);
             expect(dummyClass.getDependency()).to.be.an.instanceOf(MockDummyDependency);
         });
+
+        it('should resolve a class with nested dependencies mocked at the second level', function() {
+            mockableContainer.substitute(DummyDependency, MockDummyDependency);
+            var dummyClass = mockableContainer.resolve(DummyWithNestedDependencies);
+
+            expect(dummyClass).to.be.an.instanceOf(DummyWithNestedDependencies);
+
+            expect(dummyClass.getDependency()).to.be.an.instanceOf(DummyWithDependency);
+            expect(dummyClass.getDependency().getDependency()).to.be
+                .an.instanceOf(MockDummyDependency);
+        });
+        it('should resolve a class with nested dependencies mocked at the first level', function() {
+            mockableContainer.substitute(DummyWithDependency, MockDummyDependency);
+            var dummyClass = mockableContainer.resolve(DummyWithNestedDependencies);
+
+            expect(dummyClass).to.be.an.instanceOf(DummyWithNestedDependencies);
+
+            expect(dummyClass.getDependency()).to.be.an.instanceOf(MockDummyDependency);
+            expect(dummyClass.getDependency().getDependency).to.be.undefined;
+        });
+
+
     });
 
     context("without mocks specified", function() {

--- a/test/mockableContainer.js
+++ b/test/mockableContainer.js
@@ -1,0 +1,137 @@
+
+import {expect} from 'chai';
+
+import {dependencies, singleton} from '../src/index';
+
+import container from '../src/mockableContainer';
+
+
+class DummyDependency {
+    constructor() {
+
+    }
+}
+
+class SecondDummyDependency {
+    constructor() {
+
+    }
+}
+
+@dependencies(DummyDependency)
+class DummyWithDependency {
+    constructor(dummyDependency) {
+        this._dependency = dummyDependency;
+    }
+
+    getDependency() {
+        return this._dependency;
+    }
+}
+
+@dependencies(DummyWithDependency)
+class DummyWithNestedDependencies {
+    constructor(dummyWithDependency) {
+        this._dependency = dummyWithDependency;
+    }
+
+    getDependency() {
+        return this._dependency;
+    }
+}
+
+@singleton
+class Singleton {
+
+}
+
+describe('mockableContainer', function() {
+  context("unchanged behaviors from container", function() {
+    describe('#resolveAll()', function() {
+        it('should resolve a single class with no dependencies to the correct instance', function() {
+            var dependencies = container.resolveAll(DummyDependency);
+
+            expect(dependencies).to.be.an.instanceOf(Array);
+            expect(dependencies).to.have.length(1);
+
+            expect(dependencies[0]).to.be.an.instanceOf(DummyDependency);
+        });
+
+        it('should resolve multiple classes-- none of them with dependencies', function() {
+            var dependencies = container.resolveAll(DummyDependency, SecondDummyDependency);
+
+            expect(dependencies).to.be.an.instanceOf(Array);
+            expect(dependencies).to.have.length(2);
+
+            expect(dependencies[0]).to.be.an.instanceOf(DummyDependency);
+            expect(dependencies[1]).to.be.an.instanceOf(SecondDummyDependency);
+        });
+    });
+
+    describe('#resolve()', function() {
+        it('should resolve a class with no dependencies to an instance of itself', function() {
+            var dummyClass = container.resolve(DummyDependency);
+
+            expect(dummyClass).to.be.an.instanceOf(DummyDependency);
+        });
+
+        it('should resolve a class with a single dependency', function() {
+            var dummyClass = container.resolve(DummyWithDependency);
+
+            expect(dummyClass).to.be.an.instanceOf(DummyWithDependency);
+            expect(dummyClass.getDependency()).to.be.an.instanceOf(DummyDependency);
+        });
+
+        it('should resolve a class with nested dependencies', function() {
+            var dummyClass = container.resolve(DummyWithNestedDependencies);
+
+            expect(dummyClass).to.be.an.instanceOf(DummyWithNestedDependencies);
+
+            expect(dummyClass.getDependency()).to.be.an.instanceOf(DummyWithDependency);
+            expect(dummyClass.getDependency().getDependency()).to.be
+                .an.instanceOf(DummyDependency);
+        });
+
+        it('should resolve the same class every time if it is a singleton', function() {
+            var singletonInstance = container.resolve(Singleton);
+
+            singletonInstance.value = 'hello-world';
+
+            var singletonInstanceTwo = container.resolve(Singleton);
+
+            expect(singletonInstance).to.equal(singletonInstanceTwo);
+            expect(singletonInstance.value).to.equal(singletonInstanceTwo.value);
+        })
+    });
+
+    describe('#registerInstance()', function() {
+        it('should register an instance as a singleton', function() {
+            var instance = {
+                hello: 'world'
+            };
+
+            container.registerInstance(Singleton, instance);
+
+            var newInstance = container.resolve(Singleton);
+
+            expect(newInstance).to.equal(instance);
+        });
+
+        it('should throw an error if a non-object/non-function is passed in as an instance', function() {
+            expect(container.registerInstance.bind(container, Singleton, 1)).to
+                .throw('The argument passed was an invalid type.');
+        });
+    });
+
+    describe('#normalizeClass()', function() {
+        it('should return the class constructor unmodified if one is passed in', function() {
+            expect(container.normalizeClass(DummyDependency)).to.equal(DummyDependency);
+        });
+
+        it('should throw an error if the provided "class name" is not a string or constructor', function() {
+            expect(container.normalizeClass.bind(container, {})).to.throw('Unable to resolve the'
+                + ' dependency name to the class.');
+        });
+    });
+  });
+});

--- a/test/mockableContainer.js
+++ b/test/mockableContainer.js
@@ -82,8 +82,6 @@ describe('mockableContainer', function() {
             expect(dummyClass.getDependency()).to.be.an.instanceOf(MockDummyDependency);
             expect(dummyClass.getDependency().getDependency).to.be.undefined;
         });
-
-
     });
 
     context("without mocks specified", function() {

--- a/test/mockableContainer.js
+++ b/test/mockableContainer.js
@@ -3,7 +3,7 @@ import {expect} from 'chai';
 
 import {dependencies, singleton} from '../src/index';
 
-import container from '../src/mockableContainer';
+import mockableContainer from '../src/mockableContainer';
 
 
 class DummyDependency {
@@ -45,93 +45,108 @@ class Singleton {
 
 }
 
+class MockDummyDependency{
+  constructor() {}
+}
+
 describe('mockableContainer', function() {
-  context("unchanged behaviors from container", function() {
-    describe('#resolveAll()', function() {
-        it('should resolve a single class with no dependencies to the correct instance', function() {
-            var dependencies = container.resolveAll(DummyDependency);
 
-            expect(dependencies).to.be.an.instanceOf(Array);
-            expect(dependencies).to.have.length(1);
-
-            expect(dependencies[0]).to.be.an.instanceOf(DummyDependency);
-        });
-
-        it('should resolve multiple classes-- none of them with dependencies', function() {
-            var dependencies = container.resolveAll(DummyDependency, SecondDummyDependency);
-
-            expect(dependencies).to.be.an.instanceOf(Array);
-            expect(dependencies).to.have.length(2);
-
-            expect(dependencies[0]).to.be.an.instanceOf(DummyDependency);
-            expect(dependencies[1]).to.be.an.instanceOf(SecondDummyDependency);
-        });
-    });
-
-    describe('#resolve()', function() {
-        it('should resolve a class with no dependencies to an instance of itself', function() {
-            var dummyClass = container.resolve(DummyDependency);
-
-            expect(dummyClass).to.be.an.instanceOf(DummyDependency);
-        });
-
-        it('should resolve a class with a single dependency', function() {
-            var dummyClass = container.resolve(DummyWithDependency);
+    context("with mocks specified", function(){
+        it.only('should resolve a class with a single mocked dependency', function() {
+            mockableContainer.substitute(DummyDependency, MockDummyDependency);
+            var dummyClass = mockableContainer.resolve(DummyWithDependency);
 
             expect(dummyClass).to.be.an.instanceOf(DummyWithDependency);
-            expect(dummyClass.getDependency()).to.be.an.instanceOf(DummyDependency);
-        });
-
-        it('should resolve a class with nested dependencies', function() {
-            var dummyClass = container.resolve(DummyWithNestedDependencies);
-
-            expect(dummyClass).to.be.an.instanceOf(DummyWithNestedDependencies);
-
-            expect(dummyClass.getDependency()).to.be.an.instanceOf(DummyWithDependency);
-            expect(dummyClass.getDependency().getDependency()).to.be
-                .an.instanceOf(DummyDependency);
-        });
-
-        it('should resolve the same class every time if it is a singleton', function() {
-            var singletonInstance = container.resolve(Singleton);
-
-            singletonInstance.value = 'hello-world';
-
-            var singletonInstanceTwo = container.resolve(Singleton);
-
-            expect(singletonInstance).to.equal(singletonInstanceTwo);
-            expect(singletonInstance.value).to.equal(singletonInstanceTwo.value);
-        })
-    });
-
-    describe('#registerInstance()', function() {
-        it('should register an instance as a singleton', function() {
-            var instance = {
-                hello: 'world'
-            };
-
-            container.registerInstance(Singleton, instance);
-
-            var newInstance = container.resolve(Singleton);
-
-            expect(newInstance).to.equal(instance);
-        });
-
-        it('should throw an error if a non-object/non-function is passed in as an instance', function() {
-            expect(container.registerInstance.bind(container, Singleton, 1)).to
-                .throw('The argument passed was an invalid type.');
+            expect(dummyClass.getDependency()).to.be.an.instanceOf(MockDummyDependency);
         });
     });
 
-    describe('#normalizeClass()', function() {
-        it('should return the class constructor unmodified if one is passed in', function() {
-            expect(container.normalizeClass(DummyDependency)).to.equal(DummyDependency);
+    context("without mocks specified", function() {
+        describe('#resolveAll()', function() {
+            it('should resolve a single class with no dependencies to the correct instance', function() {
+                var dependencies = mockableContainer.resolveAll(DummyDependency);
+
+                expect(dependencies).to.be.an.instanceOf(Array);
+                expect(dependencies).to.have.length(1);
+
+                expect(dependencies[0]).to.be.an.instanceOf(DummyDependency);
+            });
+
+            it('should resolve multiple classes-- none of them with dependencies', function() {
+                var dependencies = mockableContainer.resolveAll(DummyDependency, SecondDummyDependency);
+
+                expect(dependencies).to.be.an.instanceOf(Array);
+                expect(dependencies).to.have.length(2);
+
+                expect(dependencies[0]).to.be.an.instanceOf(DummyDependency);
+                expect(dependencies[1]).to.be.an.instanceOf(SecondDummyDependency);
+            });
         });
 
-        it('should throw an error if the provided "class name" is not a string or constructor', function() {
-            expect(container.normalizeClass.bind(container, {})).to.throw('Unable to resolve the'
-                + ' dependency name to the class.');
+        describe('#resolve()', function() {
+            it('should resolve a class with no dependencies to an instance of itself', function() {
+                var dummyClass = mockableContainer.resolve(DummyDependency);
+
+                expect(dummyClass).to.be.an.instanceOf(DummyDependency);
+            });
+
+            it('should resolve a class with a single dependency', function() {
+                var dummyClass = mockableContainer.resolve(DummyWithDependency);
+
+                expect(dummyClass).to.be.an.instanceOf(DummyWithDependency);
+                expect(dummyClass.getDependency()).to.be.an.instanceOf(DummyDependency);
+            });
+
+            it('should resolve a class with nested dependencies', function() {
+                var dummyClass = mockableContainer.resolve(DummyWithNestedDependencies);
+
+                expect(dummyClass).to.be.an.instanceOf(DummyWithNestedDependencies);
+
+                expect(dummyClass.getDependency()).to.be.an.instanceOf(DummyWithDependency);
+                expect(dummyClass.getDependency().getDependency()).to.be
+                    .an.instanceOf(DummyDependency);
+            });
+
+            it('should resolve the same class every time if it is a singleton', function() {
+                var singletonInstance = mockableContainer.resolve(Singleton);
+
+                singletonInstance.value = 'hello-world';
+
+                var singletonInstanceTwo = mockableContainer.resolve(Singleton);
+
+                expect(singletonInstance).to.equal(singletonInstanceTwo);
+                expect(singletonInstance.value).to.equal(singletonInstanceTwo.value);
+            })
+        });
+
+        describe('#registerInstance()', function() {
+            it('should register an instance as a singleton', function() {
+                var instance = {
+                    hello: 'world'
+                };
+
+                mockableContainer.registerInstance(Singleton, instance);
+
+                var newInstance = mockableContainer.resolve(Singleton);
+
+                expect(newInstance).to.equal(instance);
+            });
+
+            it('should throw an error if a non-object/non-function is passed in as an instance', function() {
+                expect(mockableContainer.registerInstance.bind(mockableContainer, Singleton, 1)).to
+                    .throw('The argument passed was an invalid type.');
+            });
+        });
+
+        describe('#normalizeClass()', function() {
+            it('should return the class constructor unmodified if one is passed in', function() {
+                expect(mockableContainer.normalizeClass(DummyDependency)).to.equal(DummyDependency);
+            });
+
+            it('should throw an error if the provided "class name" is not a string or constructor', function() {
+                expect(mockableContainer.normalizeClass.bind(mockableContainer, {})).to.throw('Unable to resolve the'
+                    + ' dependency name to the class.');
+            });
         });
     });
-  });
 });


### PR DESCRIPTION
I needed the same facility requested in #6 : the ability to mock some dependencies in test.   This pull request implements such a feature, with documentation and tests.

I intentionally didn't include the new code in the main exports of index.js, it needs a separate import by the end user.  The reason is that I like how small needlepoint is (my company builds widgets, not SPAs),  so I didn't want the mocking code to be included in production builds.

Please let me know if you'd like this pull request, and if you're still maintaining the project.  Thanks!
